### PR TITLE
Centralize MedicalCertificate definition

### DIFF
--- a/src/types/certificate.ts
+++ b/src/types/certificate.ts
@@ -18,6 +18,7 @@ export interface MedicalCertificate {
     docsHanded?: boolean;
     docsReceived?: boolean;
     docsSent?: boolean;
+    requestSent?: boolean;
   };
   createdAt: string;
   updatedAt: string;

--- a/src/types/patient.ts
+++ b/src/types/patient.ts
@@ -1,4 +1,5 @@
 import { InsuranceType, PatientStatus } from './enums';
+import type { MedicalCertificate as Certificate } from './certificate';
 
 
 export interface CertificateStatus {
@@ -10,21 +11,7 @@ export interface CertificateStatus {
   status: 'ACTIVE' | 'ONHOLD' | 'EXPIRED'; // ← 新構造
 }
 
-export interface MedicalCertificate {
-  needsCertificate?: boolean;
-  sendDate?: string;
-  initialStartDate?: string; // ← ここに移動
-  grade?: string;            // ← ここに移動
-  limitAmount?: string;      // ← ここに移動
-
-  progress?: {
-    docsReady?: boolean;
-    docsHanded?: boolean;
-    docsReceived?: boolean;
-    docsSent?: boolean;
-    requestSent?: boolean;
-  };
-}
+export { Certificate as MedicalCertificate };
 
 
 export interface Patient {


### PR DESCRIPTION
## Summary
- add `requestSent` to `MedicalCertificate` progress tracking
- re-export `MedicalCertificate` from patient types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fe2dca1508333b81b2a308c4c0b9e