### PR TITLE
Fix editable cell state sync

### DIFF
--- a/src/components/EditableCell.tsx
+++ b/src/components/EditableCell.tsx
@@ -34,6 +34,8 @@ const EditableCell: React.FC<EditableCellProps> = ({
     }
   }, [isEditing]);
 
+  useEffect(() => setEditValue(value), [value]);
+
   const handleClick = () => {
     setIsEditing(true);
   };


### PR DESCRIPTION
## Summary
- sync `EditableCell` value state when props change
- ensure a newline at EOF

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ff7545090833395038d171e5ca9e7