### PR TITLE
Fix certificate creation on date change

### DIFF
--- a/MANUAL_TESTS.md
+++ b/MANUAL_TESTS.md
@@ -1,0 +1,9 @@
+# Manual Verification
+
+## Date entry with new certificate
+1. Create or locate a patient without any medical certificates.
+2. Open the Certificate Details modal for that patient.
+3. Enter values in the "新規申請受付日" or "新規申請完了日" fields.
+4. Close the modal.
+5. Reopen the modal or refresh the patient list.
+6. Verify that a new certificate record has been created and that the entered dates persist.

--- a/MANUAL_TESTS.md
+++ b/MANUAL_TESTS.md
@@ -1,9 +1,0 @@
-# Manual Verification
-
-## Date entry with new certificate
-1. Create or locate a patient without any medical certificates.
-2. Open the Certificate Details modal for that patient.
-3. Enter values in the "新規申請受付日" or "新規申請完了日" fields.
-4. Close the modal.
-5. Reopen the modal or refresh the patient list.
-6. Verify that a new certificate record has been created and that the entered dates persist.

--- a/src/components/CertificateDetailsModal.tsx
+++ b/src/components/CertificateDetailsModal.tsx
@@ -422,12 +422,26 @@ const handleDateChange = async (
   const certKey = `${type}MedicalCertificate` as keyof Patient;
   const statusKey = `${type}Status` as keyof Patient;
 
-  const cert = updatedPatient[certKey] as MedicalCertificate;
+  let cert = updatedPatient[certKey] as MedicalCertificate | undefined;
   const status = updatedPatient[statusKey] as CertificateStatus;
 
   if (!cert) {
-    console.warn('⚠️ certが存在しません:', certKey);
-    return;
+    console.warn('⚠️ cert が undefined なので初期化するよ！');
+    updatedPatient[certKey] = {
+      id: `${normalizedPatient.id}-${type}`,
+      patientId: normalizedPatient.id,
+      type: (() => {
+        if (type === 'selfSupport') return '自立支援';
+        if (type === 'disability') return '手帳';
+        return '年金';
+      })(),
+      progress: {},
+      needsCertificate: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any;
+
+    cert = updatedPatient[certKey] as MedicalCertificate;
   }
 
   const formatted = value ? `${value}T00:00:00Z` : undefined;


### PR DESCRIPTION
## Summary
- initialize a new `MedicalCertificate` when a date change occurs without an existing certificate

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68402d93c1d08333b4f50658f580de53