### PR TITLE
Load certificate status from certificates

### DIFF
--- a/src/context/PatientContext.tsx
+++ b/src/context/PatientContext.tsx
@@ -98,11 +98,30 @@ const enriched = data.map((patient) => {
   const getCert = (type: string) =>
     certs.find(cert => cert.patientId === patient.id && cert.type === type);
 
+  const selfCert = getCert('自立支援');
+  const disabilityCert = getCert('手帳');
+  const pensionCert = getCert('年金');
+
+  const toStatus = (cert: MedicalCertificate | undefined) =>
+    cert
+      ? {
+          applicationDate: cert.applicationDate,
+          completionDate: cert.completionDate,
+          startDate: cert.startDate,
+          validFrom: cert.validFrom,
+          validUntil: cert.validUntil,
+          status: cert.status as any,
+        }
+      : undefined;
+
   const result = {
     ...patient,
-    selfSupportMedicalCertificate: getCert('自立支援') ?? patient.selfSupportMedicalCertificate,
-    disabilityMedicalCertificate: getCert('手帳') ?? patient.disabilityMedicalCertificate,
-    pensionMedicalCertificate: getCert('年金') ?? patient.pensionMedicalCertificate,
+    selfSupportMedicalCertificate: selfCert ?? patient.selfSupportMedicalCertificate,
+    disabilityMedicalCertificate: disabilityCert ?? patient.disabilityMedicalCertificate,
+    pensionMedicalCertificate: pensionCert ?? patient.pensionMedicalCertificate,
+    selfSupportStatus: toStatus(selfCert) ?? patient.selfSupportStatus,
+    disabilityStatus: toStatus(disabilityCert) ?? patient.disabilityStatus,
+    pensionStatus: toStatus(pensionCert) ?? patient.pensionStatus,
   };
 
   console.log(`🟨 enriched[${patient.name}]`, {


### PR DESCRIPTION
## Summary
- create helper `toStatus` in `loadPatientsWithCertificates`
- set selfSupportStatus, disabilityStatus and pensionStatus when combining patient data with certificates

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find ESLint package)*

------
https://chatgpt.com/codex/tasks/task_e_6840328124e48333a24b323f1856c915