### PR TITLE
Add backend start and migrate scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,4 @@ VITE_API_BASE_URL=<URL of your API server>
 
 For local development it defaults to `http://localhost:3001`.
 
-## Backend Scripts
-
-Run the backend server with:
-
-```
-npm run start:backend
-```
-
-This command starts `back-end/server.ts` via `ts-node`. The server imports `db.ts`, so the `migratePatientsTable()` function runs automatically at startup.
-
-To run the migration standalone, use:
-
-```
-npm run migrate
-```
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ VITE_API_BASE_URL=<URL of your API server>
 
 For local development it defaults to `http://localhost:3001`.
 
+## Backend Scripts
+
+Run the backend server with:
+
+```
+npm run start:backend
+```
+
+This command starts `back-end/server.ts` via `ts-node`. The server imports `db.ts`, so the `migratePatientsTable()` function runs automatically at startup.
+
+To run the migration standalone, use:
+
+```
+npm run migrate
+```
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "start:backend": "ts-node back-end/server.ts",
+    "migrate": "ts-node back-end/db.ts"
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- add `start:backend` and `migrate` scripts to `package.json`
- document backend scripts in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68404358e6ac8333b0a7d7c3f168678f