### PR TITLE
Fix certificate status editing

### DIFF
--- a/src/components/CertificateDetailsModal.tsx
+++ b/src/components/CertificateDetailsModal.tsx
@@ -444,18 +444,26 @@ const handleDateChange = async (
     cert = updatedPatient[certKey] as MedicalCertificate;
   }
 
-  const formatted = value ? `${value}T00:00:00Z` : undefined;
+  const dateFields = [
+    'applicationDate',
+    'completionDate',
+    'startDate',
+    'initialStartDate',
+    'validFrom',
+    'validUntil',
+    'sendDate'
+  ];
+  const isDateField = dateFields.includes(field);
+  const formatted = value && isDateField ? `${value}T00:00:00Z` : value ?? undefined;
 
   if (target === 'status') {
-    (status as any)[field] = formatted ?? value ?? undefined;
+    (status as any)[field] = formatted;
     updatedPatient[statusKey] = status;
   } else if (target === 'medical') {
     if (field === 'needsCertificate') {
       cert.needsCertificate = value === '要';
-    } else if (field === 'startDate') {
-      cert.startDate = formatted ?? value ?? undefined;
     } else {
-      (cert as any)[field] = formatted ?? value ?? undefined;
+      (cert as any)[field] = formatted;
     }
 
     cert.updatedAt = new Date().toISOString();


### PR DESCRIPTION
## Summary
- fix incorrect date formatting in `CertificateDetailsModal` so status cells can be edited

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68416c9eaeb083339752ab74dd87715a