### PR TITLE
Fix status preservation when updating certificates

### DIFF
--- a/src/components/CertificateDetailsModal.tsx
+++ b/src/components/CertificateDetailsModal.tsx
@@ -459,6 +459,9 @@ const handleDateChange = async (
   if (target === 'status') {
     (status as any)[field] = formatted;
     updatedPatient[statusKey] = status;
+    if (field === 'status') {
+      (cert as any).status = formatted;
+    }
   } else if (target === 'medical') {
     if (field === 'needsCertificate') {
       cert.needsCertificate = value === '要';
@@ -488,6 +491,7 @@ const handleDateChange = async (
     })(),
     needsCertificate: cert.needsCertificate,
     progress: cert.progress,
+    status: status?.status,
     sendDate: cert.sendDate,
     applicationDate: status?.applicationDate,
     completionDate: status?.completionDate,
@@ -511,6 +515,7 @@ const handleProgressChange = async (
   const updatedPatient = { ...normalizedPatient };
   const key = `${type}MedicalCertificate` as keyof Patient;
   const statusKey = `${type}Status` as keyof Patient;
+  const status = updatedPatient[statusKey] as CertificateStatus;
 
   const cert = updatedPatient[key];
 
@@ -560,6 +565,7 @@ if (!cert) {
     })(),
     needsCertificate: cert.needsCertificate,
     progress: cert.progress,
+    status: status?.status,
     sendDate: cert.sendDate,
     applicationDate: status?.applicationDate,
     completionDate: status?.completionDate,


### PR DESCRIPTION
## Summary
- keep status field synced when editing certificate dates
- persist certificate status when updating progress

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68416feed56c8333826f9b080e78d2c6