### PR TITLE
Fix certificate status property names

### DIFF
--- a/src/components/NewPatientModal.tsx
+++ b/src/components/NewPatientModal.tsx
@@ -14,11 +14,11 @@ const NewPatientModal: React.FC<NewPatientModalProps> = ({ isOpen, onClose, onSu
     nameKana: '',
     chartNumber: '',
     insuranceType: 'EMPLOYEE_SELF',
-    selfSupportCertificate: {
+    selfSupportStatus: {
       hasSupport: false,
       validUntil: ''
     },
-    disabilityCertificate: {
+    disabilityStatus: {
       hasDisability: false,
       grade: '',
       validUntil: ''
@@ -123,28 +123,28 @@ const NewPatientModal: React.FC<NewPatientModalProps> = ({ isOpen, onClose, onSu
                     <input
                       type="checkbox"
                       className="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                      checked={formData.selfSupportCertificate.hasSupport}
+                      checked={formData.selfSupportStatus.hasSupport}
                       onChange={(e) => setFormData({
                         ...formData,
-                        selfSupportCertificate: {
-                          ...formData.selfSupportCertificate,
+                        selfSupportStatus: {
+                          ...formData.selfSupportStatus,
                           hasSupport: e.target.checked
                         }
                       })}
                     />
                     <span className="ml-2 font-medium">自立支援医療</span>
                   </label>
-                  {formData.selfSupportCertificate.hasSupport && (
+                  {formData.selfSupportStatus.hasSupport && (
                     <div>
                       <label className="block text-sm text-gray-700">有効期限</label>
                       <input
                         type="date"
                         className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                        value={formData.selfSupportCertificate.validUntil}
+                        value={formData.selfSupportStatus.validUntil}
                         onChange={(e) => setFormData({
                           ...formData,
-                          selfSupportCertificate: {
-                            ...formData.selfSupportCertificate,
+                          selfSupportStatus: {
+                            ...formData.selfSupportStatus,
                             validUntil: e.target.value
                           }
                         })}
@@ -159,18 +159,18 @@ const NewPatientModal: React.FC<NewPatientModalProps> = ({ isOpen, onClose, onSu
                     <input
                       type="checkbox"
                       className="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                      checked={formData.disabilityCertificate.hasDisability}
+                      checked={formData.disabilityStatus.hasDisability}
                       onChange={(e) => setFormData({
                         ...formData,
-                        disabilityCertificate: {
-                          ...formData.disabilityCertificate,
+                        disabilityStatus: {
+                          ...formData.disabilityStatus,
                           hasDisability: e.target.checked
                         }
                       })}
                     />
                     <span className="ml-2 font-medium">障害者手帳</span>
                   </label>
-                  {formData.disabilityCertificate.hasDisability && (
+                  {formData.disabilityStatus.hasDisability && (
                     <div className="space-y-2">
                       <div>
                         <label className="block text-sm text-gray-700">等級</label>
@@ -178,11 +178,11 @@ const NewPatientModal: React.FC<NewPatientModalProps> = ({ isOpen, onClose, onSu
                           type="text"
                           placeholder="例: 2級"
                           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                          value={formData.disabilityCertificate.grade}
+                          value={formData.disabilityStatus.grade}
                           onChange={(e) => setFormData({
                             ...formData,
-                            disabilityCertificate: {
-                              ...formData.disabilityCertificate,
+                            disabilityStatus: {
+                              ...formData.disabilityStatus,
                               grade: e.target.value
                             }
                           })}
@@ -193,11 +193,11 @@ const NewPatientModal: React.FC<NewPatientModalProps> = ({ isOpen, onClose, onSu
                         <input
                           type="date"
                           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                          value={formData.disabilityCertificate.validUntil}
+                          value={formData.disabilityStatus.validUntil}
                           onChange={(e) => setFormData({
                             ...formData,
-                            disabilityCertificate: {
-                              ...formData.disabilityCertificate,
+                            disabilityStatus: {
+                              ...formData.disabilityStatus,
                               validUntil: e.target.value
                             }
                           })}

--- a/src/data/sampleData.ts
+++ b/src/data/sampleData.ts
@@ -8,7 +8,7 @@ export const samplePatients: Patient[] = [
     nameKana: 'ヤマダ タロウ',
     chartNumber: 'CH001',
     insuranceType: InsuranceType.EMPLOYEE_SELF,
-    selfSupportCertificate: {
+    selfSupportStatus: {
       hasSupport: true,
       validUntil: '2025-03-31T00:00:00Z',
       initialStartDate: '2023-04-01T00:00:00Z',
@@ -26,7 +26,7 @@ export const samplePatients: Patient[] = [
         requestSent: true
       }
     },
-    disabilityCertificate: {
+    disabilityStatus: {
       hasDisability: true,
       grade: '2級',
       validUntil: '2025-03-31T00:00:00Z',
@@ -97,7 +97,7 @@ export const samplePatients: Patient[] = [
     nameKana: 'スズキ ハナコ',
     chartNumber: 'CH002',
     insuranceType: InsuranceType.EMPLOYEE_FAMILY,
-    selfSupportCertificate: {
+    selfSupportStatus: {
       hasSupport: false,
       status: 'ACTIVE',
       needsCertificate: false,
@@ -105,7 +105,7 @@ export const samplePatients: Patient[] = [
         requestSent: false
       }
     },
-    disabilityCertificate: {
+    disabilityStatus: {
       hasDisability: true,
       grade: '1級',
       validUntil: '2024-09-30T00:00:00Z',
@@ -155,7 +155,7 @@ export const samplePatients: Patient[] = [
     nameKana: 'サトウ イチロウ',
     chartNumber: 'CH003',
     insuranceType: InsuranceType.LIFE,
-    selfSupportCertificate: {
+    selfSupportStatus: {
       hasSupport: true,
       validUntil: '2024-12-31T00:00:00Z',
       initialStartDate: '2022-01-01T00:00:00Z',
@@ -173,7 +173,7 @@ export const samplePatients: Patient[] = [
         requestSent: true
       }
     },
-    disabilityCertificate: {
+    disabilityStatus: {
       hasDisability: true,
       grade: '3級',
       validUntil: '2024-12-31T00:00:00Z',

--- a/src/pages/MedicalCertificates.tsx
+++ b/src/pages/MedicalCertificates.tsx
@@ -733,7 +733,7 @@ const updateCertificateRow = (rowId: string, field: 'priority' | 'staff' | 'stat
                   <span>{row.type}</span>
                 </td>
                 <td className="px-6 py-4">
-                  {row.renewalType === '新規' && row.patient[`${row.type === '自立支援' ? 'selfSupportCertificate' : row.type === '手帳' ? 'disabilityCertificate' : 'pensionStatus'}`].progress?.requestSent
+                  {row.renewalType === '新規' && row.patient[`${row.type === '自立支援' ? 'selfSupportStatus' : row.type === '手帳' ? 'disabilityStatus' : 'pensionStatus'}`].progress?.requestSent
                     ? (row.applicationDate
                         ? new Date(row.applicationDate).toLocaleDateString('ja-JP')
                         : '-')

--- a/src/pages/PatientList.tsx
+++ b/src/pages/PatientList.tsx
@@ -95,11 +95,11 @@ const PatientList: React.FC = () => {
       nameKana: '',
       chartNumber: '',
       insuranceType: '' as any,
-      selfSupportCertificate: {
+      selfSupportStatus: {
         hasSupport: false,
         status: '未更新'
       },
-      disabilityCertificate: {
+      disabilityStatus: {
         hasDisability: false,
         status: '未更新'
       },
@@ -202,12 +202,12 @@ const PatientList: React.FC = () => {
             compareB = insuranceTypes[b.insuranceType];
             break;
           case 'medicalType':
-            compareA = getCertificateStatus(a.selfSupportCertificate);
-            compareB = getCertificateStatus(b.selfSupportCertificate);
+            compareA = getCertificateStatus(a.selfSupportStatus);
+            compareB = getCertificateStatus(b.selfSupportStatus);
             break;
           case 'medicalDeadline':
-            compareA = a.selfSupportCertificate?.validUntil;
-            compareB = b.selfSupportCertificate?.validUntil;
+            compareA = a.selfSupportStatus?.validUntil;
+            compareB = b.selfSupportStatus?.validUntil;
             break;
         }
 
@@ -497,8 +497,8 @@ const PatientList: React.FC = () => {
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {sortedPatients.map((patient) => {
-              const selfSupportStatus = getCertificateStatus(patient.selfSupportCertificate);
-              const disabilityStatus = getCertificateStatus(patient.disabilityCertificate);
+              const selfSupportStatus = getCertificateStatus(patient.selfSupportStatus);
+              const disabilityStatus = getCertificateStatus(patient.disabilityStatus);
               const pensionStatus = getCertificateStatus(patient.pensionStatus);
 
               return (

--- a/src/pages/StopList.tsx
+++ b/src/pages/StopList.tsx
@@ -224,12 +224,12 @@ const StopList: React.FC = () => {
                 </td>
                 <td className="px-3 py-4">
                   <div className="text-sm">
-                    {getCertificateStatus(patient.selfSupportCertificate)}
+                    {getCertificateStatus(patient.selfSupportStatus)}
                   </div>
                 </td>
                 <td className="px-3 py-4">
                   <div className="text-sm">
-                    {getCertificateStatus(patient.disabilityCertificate)}
+                    {getCertificateStatus(patient.disabilityStatus)}
                   </div>
                 </td>
                 <td className="px-3 py-4">


### PR DESCRIPTION
## Summary
- rename `selfSupportCertificate` and `disabilityCertificate` to `selfSupportStatus`/`disabilityStatus`
- update patient table sorting and display
- adapt StopList certificate status fields
- use new field names in MedicalCertificates dynamic lookups
- update new patient modal and sample data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417516ca1083339827bef320d8a354